### PR TITLE
Support Net::Netmask >= 2.0000

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Plack-Middleware-RealIP
 
+0.04    ???
+          - Support Net::Netmask >= 2.0000
+
 0.03    Sun Apr  8 00:18:13 PHT 2012
           - Perlcritic fixes
           - Specified MIN_PERL_VERSION in Makefile.PL

--- a/lib/Plack/Middleware/RealIP.pm
+++ b/lib/Plack/Middleware/RealIP.pm
@@ -10,6 +10,7 @@ use Plack::Util::Accessor qw( header trusted_proxy );
 
 sub prepare_app {
     my $self = shift;
+    local $Net::Netmask::SHORTNET_DEFAULT = 1;
 
     if (my $trusted_proxy = $self->trusted_proxy) {
         my @trusted_proxy = map { Net::Netmask->new($_) } ref($trusted_proxy) ? @{ $trusted_proxy } : ($trusted_proxy);


### PR DESCRIPTION
Net::Netmask 2.0000 (will be released today) no longer supports the "shortnet" format by default - I.E. ranges like 127/8 will no longer be supported by default due to ambiguity among different libraries and systems. Activating the Net::Netmask::SHORTNET_DEFAULT flag allows the old behavior (which allows Plack::Middleware::RealIP to continue work properly).  This flag change is backwards compatible with older Net::Netmasks.